### PR TITLE
Add pythonista.classes proxy module for loading ObjCClasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Download the repo in zip format and extract it, or `git clone` it using [stash](
 
 The code is now broken into several submodules:
 
-* `pythonista.app`, which contains functions for setting the badge string/number, clearing the badge, and opening URLs in an `appex`-safe way.
-* `pythonista.console`, which contains functions for getting the current and default console fonts.
-* `pythonista.editor`, which contains the `Tab` and `WebTab` classes.
+* `pythonista.app` contains functions for setting the badge string/number, clearing the badge, and opening URLs in an `appex`-safe way.
+* `pythonista.classes` is a proxy module that can be used to load Objective-C classes. For example `pythonista.classes.NSObject == objc_util.ObjCClass("NSObject")`.
+* `pythonista.console` contains functions for getting the current and default console fonts.
+* `pythonista.editor` contains the `Tab` and `WebTab` classes.
+* `pythonista.shared` contains a few commonly used objects, such as the shared application and a few view controllers.
 
-**Note:** Please do NOT use `from pythonista import *`, as this will cause name conflicts with the default `console` and `editor` modules. Instead, use it only with `import pythonista`, as this way the module's submodules will not overwrite Pythonista's default ones. It is fine to use `from pythonista.module import *` with any of the submodules.
+**Note:** Please do NOT use `from pythonista import *`, as this will cause name conflicts with the default `console` and `editor` modules. Instead, use it only with `import pythonista`, as this way the module's submodules will not overwrite Pythonista's default ones. It is fine to use `from pythonista.module import *` with all submodules except for `pythonista.classes`.
 
 As of right now, each submodule contains only a small amount of functionality, but as they're expanded, the submodule approach will make much more sense.
 

--- a/pythonista/__init__.py
+++ b/pythonista/__init__.py
@@ -1,3 +1,42 @@
 """Root of the pythonista package."""
 
-# Contains no actual code. This is just here to make pythonista a package.
+import objc_util
+import sys
+
+__all__ = []
+
+# Install the loader for pythonista.classes.
+
+# Note: objc_util already caches ObjCClass instances. We don't need to worry about that.
+class ObjCClassModuleProxy(type(sys)):
+	def __dir__(self):
+		return list(sorted(set(self.__dict__.keys()) | set(objc_util._cached_classes.keys())))
+
+	def __getattr__(self, name):
+		try:
+			return objc_util.ObjCClass(name)
+		except ValueError as err:
+			raise AttributeError(err.message)
+
+class FinderLoaderForClasses(object):
+	def find_module(self, fullname, path=None):
+		return self if fullname == "pythonista.classes" else None
+	
+	def load_module(self, fullname):
+		assert fullname == "pythonista.classes"
+		mod = sys.modules.setdefault(fullname, ObjCClassModuleProxy(fullname))
+		mod.__file__ = "<dynamically created by {cls.__module__}.{cls.__name__}>".format(cls=type(self))
+		mod.__loader__ = self
+		mod.__package__ = "pythonista"
+		mod.__all__ = ["NSDontEvenTryToStarImportThisModuleYouCrazyPerson"]
+		return mod
+
+# This is for removing old versions of the loader if the pythonista module is reloaded.
+for obj in sys.meta_path:
+	if type(obj).__module__ == "pythonista" and type(obj).__name__ == "FinderLoaderForClasses":
+		sys.meta_path.remove(obj)
+		break
+
+sys.meta_path.append(FinderLoaderForClasses())
+from . import classes
+reload(classes)

--- a/pythonista/app.py
+++ b/pythonista/app.py
@@ -1,7 +1,8 @@
 """Miscellaneous functions for controlling the app."""
 
+from objc_util import nsurl, on_main_thread
+
 from . import shared
-from .shared import on_main_thread
 
 __all__ = [
 	"clearBadge",
@@ -30,4 +31,4 @@ def clearBadge():
 def openURL(url):
 	"""Open a url in a way that works through appex. This is useful for using
 	URL schemes to open other apps with data gained from appex."""
-	shared.app._openURL_(shared.nsurl(url))
+	shared.app._openURL_(nsurl(url))

--- a/pythonista/classes.py
+++ b/pythonista/classes.py
@@ -1,0 +1,6 @@
+# This is not the real classes module.
+# The first tim you import the pythonista module, it installs a custom loader for this module into sys.meta_path, so this file is never loaded.
+# The loader creates an instance of ObjCClassModuleProxy and uses that as the module pythonista.classes.
+# ObjCClassModuleProxy is a subclass of the built-in module type. It overrides __getattr__ so that pythonista.classes.ClassName is the same as objc_util.ObjCClass("ClassName"). The main purpose of this is that you can quickly load multiple Objective-C classes using a normal from import.
+
+raise ImportError("This file should never be imported. The pythonista.classes module must be loaded by a custom loader that should have been installed by the pythonista module.")

--- a/pythonista/console.py
+++ b/pythonista/console.py
@@ -1,7 +1,8 @@
 """Methods relating to the console."""
 
+from objc_util import on_main_thread
+
 from . import shared
-from .shared import on_main_thread
 
 __all__ = [
 	"getConsoleFont",

--- a/pythonista/shared.py
+++ b/pythonista/shared.py
@@ -1,17 +1,12 @@
-import objc_util
-from objc_util import *
+from .classes import NSUserDefaults, UIApplication
 
-__all__ = sorted(set('''app consoleVC NSDataDetector NSURLRequest NSUserDefaults
-rootVC tabVC UIBarButtonItem UISearchBar userDefaults WKWebView'''.split()) | {
-name for name in dir(objc_util) if not name.startswith('_')} - set('''ctypes
-inspect itertools os pp re string sys ui weakref'''.split()))
-
-NSDataDetector = ObjCClass("NSDataDetector")
-NSURLRequest = ObjCClass("NSURLRequest")
-NSUserDefaults = ObjCClass("NSUserDefaults")
-UIBarButtonItem = ObjCClass("UIBarButtonItem")
-UISearchBar = ObjCClass("UISearchBar")
-WKWebView = ObjCClass("WKWebView")
+__all__ = [
+	"app",
+	"consoleVC",
+	"rootVC",
+	"tabVC",
+	"userDefaults",
+]
 
 app = UIApplication.sharedApplication()
 consoleVC = app.delegate().consoleViewController()


### PR DESCRIPTION
This makes it so you can write this:

``` python
from pythonista.classes import NSDataDetector, NSURLRequest, NSUserDefaults, UIBarButtonItem, UISearchBar, WKWebView
```

instead of this:

``` python
NSDataDetector = ObjCClass("NSDataDetector")
NSURLRequest = ObjCClass("NSURLRequest")
NSUserDefaults = ObjCClass("NSUserDefaults")
UIBarButtonItem = ObjCClass("UIBarButtonItem")
UISearchBar = ObjCClass("UISearchBar")
WKWebView = ObjCClass("WKWebView")
```

I also removed all of the `ObjCClass` loading from `pythonista.shared` since they can now be imported just as easily from `pythonista.classes`. And made the modules import things from `objc_util` directly again, instead of from `pythonista.shared`. It was kind of silly how everything from `objc_util` needed a `shared.` before it.
